### PR TITLE
Course requirement now has course id instead of course

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .DS_Store/
 *.log
+vendor/

--- a/internal/app/components/courses/requirements.go
+++ b/internal/app/components/courses/requirements.go
@@ -2,7 +2,7 @@ package courses
 
 // CourseRequirement(Set) are concrete
 type CourseRequirement struct {
-	Course   *Course     `json:"course"`
+	CourseId CourseId    `json:"course_id"`
 	MinGrade CourseGrade `json:"min_grade"`
 }
 
@@ -20,7 +20,7 @@ type CourseRequirementRules []CourseRequirementRule
 
 func (req CourseRequirement) IsSatisfied(courseRecords *CourseRecords) bool {
 	idMap := courseRecords.ToCourseIdMap()
-	course, completed := idMap[req.Course.Id]
+	course, completed := idMap[req.CourseId]
 	return completed && (course.Grade >= req.MinGrade || course.CompletionDate == nil)
 }
 

--- a/internal/app/components/courses/requirements_test.go
+++ b/internal/app/components/courses/requirements_test.go
@@ -9,42 +9,35 @@ import (
 func TestCourseRequirement_IsSatisfied(t *testing.T) {
 	records := initRecords()
 	// testing using future course record (record3 )
-	course := Course{
-		Id: CourseId(789),
-	}
+	courseId := CourseId(789)
 	req := CourseRequirement{
 		MinGrade: 100, // should ignore this requirement
-		Course:   &course,
+		CourseId: courseId,
 	}
 	assert.Equal(t, true, req.IsSatisfied(records), "Test future record")
 
 	// missing requirement
-	course = Course{
-		Id: CourseId(0),
-	}
+	courseId = CourseId(0)
 	req = CourseRequirement{
 		MinGrade: 0, // should ignore this requirement
-		Course:   &course,
+		CourseId: courseId,
 	}
 	assert.Equal(t, false, req.IsSatisfied(records), "Test missing record")
 
 	// doesn't meet grades requirement
-	course = Course{
-		Id: CourseId(456),
-	}
+	courseId = CourseId(456)
+
 	req = CourseRequirement{
 		MinGrade: 51, // should ignore this requirement
-		Course:   &course,
+		CourseId: courseId,
 	}
 	assert.Equal(t, false, req.IsSatisfied(records), "Test grade requirement not met")
 
 	// meets grades requirement
-	course = Course{
-		Id: CourseId(456),
-	}
+	courseId = CourseId(456)
 	req = CourseRequirement{
 		MinGrade: 50, // should ignore this requirement
-		Course:   &course,
+		CourseId: courseId,
 	}
 	assert.Equal(t, true, req.IsSatisfied(records), "Test grade requirement met")
 
@@ -58,12 +51,10 @@ func TestCourseRequirement_IsSatisfied(t *testing.T) {
 		CompletionDate: &currTime,
 	}
 	*records = append(*records, &repeatedCourse)
-	course = Course{
-		Id: CourseId(456),
-	}
+	courseId = CourseId(456)
 	req = CourseRequirement{
 		MinGrade: 51, // should ignore this requirement
-		Course:   &course,
+		CourseId: courseId,
 	}
 	assert.Equal(t, true, req.IsSatisfied(records), "Test grade requirement met after course repeated")
 }
@@ -76,21 +67,15 @@ func TestCourseRequirementSet_IsSatisfied(t *testing.T) {
 		Requirements: CourseRequirementRules{
 			CourseRequirement{
 				MinGrade: 80,
-				Course: &Course{
-					Id: CourseId(123),
-				},
+				CourseId: CourseId(123),
 			},
 			CourseRequirement{
 				MinGrade: 50,
-				Course: &Course{
-					Id: CourseId(456),
-				},
+				CourseId: CourseId(456),
 			},
 			CourseRequirement{
 				MinGrade: 100,
-				Course: &Course{
-					Id: CourseId(789),
-				},
+				CourseId: CourseId(789),
 			},
 		},
 	}
@@ -102,21 +87,15 @@ func TestCourseRequirementSet_IsSatisfied(t *testing.T) {
 		Requirements: CourseRequirementRules{
 			CourseRequirement{
 				MinGrade: 80,
-				Course: &Course{
-					Id: CourseId(123),
-				},
+				CourseId: CourseId(123),
 			},
 			CourseRequirement{
 				MinGrade: 51,
-				Course: &Course{
-					Id: CourseId(456),
-				},
+				CourseId: CourseId(456),
 			},
 			CourseRequirement{
 				MinGrade: 100,
-				Course: &Course{
-					Id: CourseId(789),
-				},
+				CourseId: CourseId(789),
 			},
 		},
 	}
@@ -128,21 +107,15 @@ func TestCourseRequirementSet_IsSatisfied(t *testing.T) {
 		Requirements: CourseRequirementRules{
 			CourseRequirement{
 				MinGrade: 80,
-				Course: &Course{
-					Id: CourseId(123),
-				},
+				CourseId: CourseId(123),
 			},
 			CourseRequirement{
 				MinGrade: 51,
-				Course: &Course{
-					Id: CourseId(456),
-				},
+				CourseId: CourseId(456),
 			},
 			CourseRequirement{
 				MinGrade: 100,
-				Course: &Course{
-					Id: CourseId(789),
-				},
+				CourseId: CourseId(789),
 			},
 		},
 	}
@@ -154,21 +127,15 @@ func TestCourseRequirementSet_IsSatisfied(t *testing.T) {
 		Requirements: CourseRequirementRules{
 			CourseRequirement{
 				MinGrade: 80,
-				Course: &Course{
-					Id: CourseId(123),
-				},
+				CourseId: CourseId(123),
 			},
 			CourseRequirement{
 				MinGrade: 51,
-				Course: &Course{
-					Id: CourseId(456),
-				},
+				CourseId: CourseId(456),
 			},
 			CourseRequirement{
 				MinGrade: 0,
-				Course: &Course{
-					Id: CourseId(0),
-				},
+				CourseId: CourseId(0),
 			},
 		},
 	}

--- a/internal/app/components/plans/plans_test.go
+++ b/internal/app/components/plans/plans_test.go
@@ -15,15 +15,11 @@ func TestDegree_IsCompleted(t *testing.T) {
 			Requirements: courses.CourseRequirementRules{
 				courses.CourseRequirement{
 					MinGrade: 50,
-					Course: &courses.Course{
-						Id: 0,
-					},
+					CourseId: 0,
 				},
 				courses.CourseRequirement{
 					MinGrade: 60,
-					Course: &courses.Course{
-						Id: 1,
-					},
+					CourseId: 1,
 				},
 			},
 		}),
@@ -78,15 +74,11 @@ func TestDegree_GetName(t *testing.T) {
 			Requirements: courses.CourseRequirementRules{
 				courses.CourseRequirement{
 					MinGrade: 50,
-					Course: &courses.Course{
-						Id: 0,
-					},
+					CourseId: 0,
 				},
 				courses.CourseRequirement{
 					MinGrade: 60,
-					Course: &courses.Course{
-						Id: 1,
-					},
+					CourseId: 1,
 				},
 			},
 		}),

--- a/internal/app/components/terms/termRecords_test.go
+++ b/internal/app/components/terms/termRecords_test.go
@@ -14,9 +14,7 @@ func TestTermRecord_InvalidCourses(t *testing.T) {
 		Course: courses.Course{
 			Id: 0,
 			Prereqs: courses.CourseRequirement{
-				Course: &courses.Course{
-					Id: 1,
-				},
+				CourseId: 1,
 				MinGrade: 60,
 			},
 		},
@@ -28,15 +26,11 @@ func TestTermRecord_InvalidCourses(t *testing.T) {
 				MinCoursesToSatisfy: 1,
 				Requirements: courses.CourseRequirementRules{
 					courses.CourseRequirement{
-						Course: &courses.Course{
-							Id: 3,
-						},
+						CourseId: 3,
 						MinGrade: 60,
 					},
 					courses.CourseRequirement{
-						Course: &courses.Course{
-							Id: 4,
-						},
+						CourseId: 4,
 						MinGrade: 60,
 					},
 				},
@@ -170,9 +164,7 @@ func Test_isPrereqSatisfied(t *testing.T) {
 					Course: courses.Course{
 						Id: 0,
 						Prereqs: courses.CourseRequirement{
-							Course: &courses.Course{
-								Id: 1,
-							},
+							CourseId: 1,
 							MinGrade: 60,
 						},
 					},
@@ -195,9 +187,7 @@ func Test_isPrereqSatisfied(t *testing.T) {
 					Course: courses.Course{
 						Id: 0,
 						Prereqs: courses.CourseRequirement{
-							Course: &courses.Course{
-								Id: 1,
-							},
+							CourseId: 1,
 							MinGrade: 60,
 						},
 					},

--- a/internal/app/components/timelines/timelines_test.go
+++ b/internal/app/components/timelines/timelines_test.go
@@ -95,15 +95,11 @@ func TestTimeline_IncompletePlans(t *testing.T) {
 			Requirements: courses.CourseRequirementRules{
 				courses.CourseRequirement{
 					MinGrade: 50,
-					Course: &courses.Course{
-						Id: 0,
-					},
+					CourseId: 0,
 				},
 				courses.CourseRequirement{
 					MinGrade: 60,
-					Course: &courses.Course{
-						Id: 1,
-					},
+					CourseId: 1,
 				},
 			},
 		}),
@@ -115,15 +111,11 @@ func TestTimeline_IncompletePlans(t *testing.T) {
 			Requirements: courses.CourseRequirementRules{
 				courses.CourseRequirement{
 					MinGrade: 50,
-					Course: &courses.Course{
-						Id: 0,
-					},
+					CourseId: 0,
 				},
 				courses.CourseRequirement{
 					MinGrade: 60,
-					Course: &courses.Course{
-						Id: 2,
-					},
+					CourseId: 2,
 				},
 			},
 		}),
@@ -135,15 +127,11 @@ func TestTimeline_IncompletePlans(t *testing.T) {
 			Requirements: courses.CourseRequirementRules{
 				courses.CourseRequirement{
 					MinGrade: 50,
-					Course: &courses.Course{
-						Id: 3,
-					},
+					CourseId: 3,
 				},
 				courses.CourseRequirement{
 					MinGrade: 50,
-					Course: &courses.Course{
-						Id: 4,
-					},
+					CourseId: 4,
 				},
 			},
 		}),
@@ -357,9 +345,7 @@ func TestTimeline_InvalidCourses(t *testing.T) {
 		Course: courses.Course{
 			Id: 1,
 			Prereqs: courses.CourseRequirement{
-				Course: &courses.Course{
-					Id: 0,
-				},
+				CourseId: 0,
 				MinGrade: 60,
 			},
 		},
@@ -368,9 +354,7 @@ func TestTimeline_InvalidCourses(t *testing.T) {
 		Course: courses.Course{
 			Id: 2,
 			Prereqs: courses.CourseRequirement{
-				Course: &courses.Course{
-					Id: 1,
-				},
+				CourseId: 1,
 				MinGrade: 60,
 			},
 		},


### PR DESCRIPTION
Don't think there is a point keeping `Course` in `CourseRequirement`