### PR TITLE
Used updated course history to create new timeline 

### DIFF
--- a/internal/app/components/courses/courseRecords.go
+++ b/internal/app/components/courses/courseRecords.go
@@ -17,6 +17,20 @@ type CourseRecord struct {
 
 type CourseRecords []*CourseRecord
 
+func CopyRecords(records CourseRecords) CourseRecords {
+	var newCourseRecords []*CourseRecord
+	for _, cr := range records {
+		newCompletionDate := cr.CompletionDate
+		if cr.CompletionDate != nil {
+			copyTime := *cr.CompletionDate
+			newCompletionDate = &copyTime
+		}
+		newRecord := CourseRecord{cr.Course, cr.Id, cr.Grade, newCompletionDate}
+		newCourseRecords = append(newCourseRecords, &newRecord)
+	}
+	return CourseRecords(newCourseRecords)
+}
+
 func GetCourseRecordById(ctx context.Context, recordId CourseRecordId) (*CourseRecord, error) {
 	// TODO: implement
 	return nil, nil

--- a/internal/app/components/courses/courseRecords_test.go
+++ b/internal/app/components/courses/courseRecords_test.go
@@ -1,13 +1,15 @@
 package courses
 
 import (
-	"github.com/gzcharleszhang/course-planner/internal/app/components/utils"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/gzcharleszhang/course-planner/internal/app/components/utils"
 )
 
 func TestCourseRecords_ToCourseIdMap(t *testing.T) {
+
 	currTime := time.Now()
 	tests := []struct {
 		name string
@@ -395,6 +397,26 @@ func TestCourseRecords_Exclude(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.cr.Exclude(tt.args.records); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("CourseRecords.Exclude() = %v, want %v", utils.ToJson(got), utils.ToJson(tt.want))
+			}
+		})
+	}
+}
+
+func TestCourseRecords_CopyRecords(t *testing.T) {
+	type args struct {
+		records CourseRecords
+	}
+	tests := []struct {
+		name string
+		args args
+		want CourseRecords
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CopyRecords(tt.args.records); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CopyCourseRecords() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/app/components/terms/termRecords.go
+++ b/internal/app/components/terms/termRecords.go
@@ -26,6 +26,18 @@ func NewTermRecord(termName TermName, uwTermId int) *TermRecord {
 	}
 }
 
+func CopyRecords(records []*TermRecord) []*TermRecord {
+	var newTermRecords []*TermRecord
+	for _, tr := range records {
+		termName, termId := tr.Term.Name, int(tr.Term.Id)
+		newRecord := NewTermRecord(termName, termId)
+		newCourseRecords := courses.CopyRecords(tr.CourseRecords)
+		newRecord.CourseRecords = newCourseRecords
+		newTermRecords = append(newTermRecords, newRecord)
+	}
+	return newTermRecords
+}
+
 // Returns the courses whose pre-requisites are not satisfied
 func (tr TermRecord) InvalidCourses(pastRecords courses.CourseRecords) courses.CourseRecords {
 	invalidRecords := courses.CourseRecords{}

--- a/internal/app/components/terms/termRecords.go
+++ b/internal/app/components/terms/termRecords.go
@@ -2,16 +2,25 @@ package terms
 
 import (
 	"github.com/gzcharleszhang/course-planner/internal/app/components/courses"
+	"github.com/rs/xid"
 )
+
+type TermRecordId string
 
 type TermRecord struct {
 	Term          Term
+	Id            TermRecordId
 	CourseRecords courses.CourseRecords
+}
+
+func newTermRecordId() TermRecordId {
+	return TermRecordId(xid.New().String())
 }
 
 func NewTermRecord(termName TermName, uwTermId int) *TermRecord {
 	return &TermRecord{
 		Term:          NewTerm(termName, uwTermId),
+		Id:						 newTermRecordId(),
 		CourseRecords: courses.CourseRecords{},
 	}
 }
@@ -34,4 +43,9 @@ func isPrereqSatisfied(record *courses.CourseRecord, pastRecords *courses.Course
 		return true
 	}
 	return record.Prereqs.IsSatisfied(pastRecords)
+}
+
+// TODO: implement
+func GetTermRecordById(id TermRecordId) TermRecord {
+	return nil
 }

--- a/internal/app/components/terms/termRecords.go
+++ b/internal/app/components/terms/termRecords.go
@@ -1,6 +1,7 @@
 package terms
 
 import (
+	"context"
 	"github.com/gzcharleszhang/course-planner/internal/app/components/courses"
 	"github.com/rs/xid"
 )
@@ -20,7 +21,7 @@ func newTermRecordId() TermRecordId {
 func NewTermRecord(termName TermName, uwTermId int) *TermRecord {
 	return &TermRecord{
 		Term:          NewTerm(termName, uwTermId),
-		Id:						 newTermRecordId(),
+		Id:            newTermRecordId(),
 		CourseRecords: courses.CourseRecords{},
 	}
 }
@@ -46,6 +47,11 @@ func isPrereqSatisfied(record *courses.CourseRecord, pastRecords *courses.Course
 }
 
 // TODO: implement
-func GetTermRecordById(id TermRecordId) TermRecord {
-	return nil
+func GetTermRecordById(ctx context.Context, id TermRecordId) (*TermRecord, error) {
+	return nil, nil
+}
+
+// TODO: implement
+func GetTermRecordsByIds(ctx context.Context, recordIds []TermRecordId) ([]*TermRecord, error) {
+	return nil, nil
 }

--- a/internal/app/components/terms/termRecords_test.go
+++ b/internal/app/components/terms/termRecords_test.go
@@ -1,12 +1,13 @@
 package terms
 
 import (
-	"github.com/gzcharleszhang/course-planner/internal/app/components/utils"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/gzcharleszhang/course-planner/internal/app/components/courses"
+	"github.com/gzcharleszhang/course-planner/internal/app/components/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTermRecord_InvalidCourses(t *testing.T) {
@@ -209,6 +210,156 @@ func Test_isPrereqSatisfied(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := isPrereqSatisfied(tt.args.record, tt.args.pastRecords); got != tt.want {
 				t.Errorf("isPrereqSatisfied() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func X(t *testing.T) {
+	currTime := time.Now()
+	termRecords := []*TermRecord{
+		{
+			Term: Term{
+				Name:   "1A",
+				Id:     1189,
+				Season: TermSeason(9),
+				Year:   2018,
+			},
+			Id: "#131ijj2",
+			CourseRecords: courses.CourseRecords{
+				&courses.CourseRecord{
+					Course: courses.Course{
+						Id: 0,
+					},
+					Grade:          85,
+					CompletionDate: &currTime,
+				},
+			},
+		},
+		{
+			Term: Term{
+				Name:   "1B",
+				Id:     1191,
+				Season: TermSeason(1),
+				Year:   2019,
+			},
+			CourseRecords: courses.CourseRecords{
+				&courses.CourseRecord{
+					Course: courses.Course{
+						Id: 1,
+					},
+					Grade:          70,
+					CompletionDate: &currTime,
+				},
+				&courses.CourseRecord{
+					Course: courses.Course{
+						Id: 2,
+					},
+					Grade:          50,
+					CompletionDate: &currTime,
+				},
+			},
+		},
+		{
+			Term: Term{
+				Name:   "2A",
+				Id:     1195,
+				Season: TermSeason(5),
+				Year:   2019,
+			},
+			CourseRecords: courses.CourseRecords{
+				&courses.CourseRecord{
+					Course: courses.Course{
+						Id: 3,
+					},
+					Grade:          50,
+					CompletionDate: &currTime,
+				},
+			},
+		},
+	}
+
+	newTermRecord := CopyRecords(termRecords)
+
+	termRecords[1].Term.Season = TermSeason(5)
+	termRecords[1].CourseRecords[1].Course.Id = 10
+	termRecords[1].CourseRecords[1].Grade = 100
+	termRecords[1].Term.Name = "3A"
+	termRecords[1].Term.Year = 3019
+
+	assert.NotEqual(t, termRecords[0].Id, newTermRecord[0].Id)
+	assert.Equal(t, termRecords[0].Term, newTermRecord[0].Term)
+	assert.NotEqual(t, termRecords[1].Term, newTermRecord[1].Term)
+
+}
+
+func TestTermRecord_CopyTermRecords(t *testing.T) {
+	currTime := time.Now()
+	type args struct {
+		records []*TermRecord
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*TermRecord
+	}{
+		// TODO: Add test cases.
+		{
+			name: "empty",
+			args: args{
+				[]*TermRecord{},
+			},
+			want: []*TermRecord{},
+		},
+		{
+			name: "single",
+			args: args{
+				 []*TermRecord{
+					{
+						Term: Term{
+							Name:   "1A",
+							Id:     1189,
+							Season: TermSeason(9),
+							Year:   2018,
+						},
+						Id: "131ijj2",
+						CourseRecords: courses.CourseRecords{
+							&courses.CourseRecord{
+								Course: courses.Course{
+									Id: 0,
+								},
+								Grade:          85,
+								CompletionDate: &currTime,
+							},
+						},
+					},
+				},
+			},
+			want: []*TermRecord{
+				{
+					Term: Term{
+						Name:   "1A",
+						Id:     1189,
+						Season: TermSeason(9),
+						Year:   2018,
+					},
+					CourseRecords: courses.CourseRecords{
+						&courses.CourseRecord{
+							Course: courses.Course{
+								Id: 0,
+							},
+							Grade:          85,
+							CompletionDate: &currTime,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CopyRecords(tt.args.records); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CopyRecords() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/app/components/terms/terms.go
+++ b/internal/app/components/terms/terms.go
@@ -3,6 +3,7 @@ package terms
 type TermName string
 type TermSeason int
 type TermYear int
+type TermId int
 
 const (
 	WINTER TermSeason = 1
@@ -12,6 +13,7 @@ const (
 
 type Term struct {
 	Name   TermName
+	Id 	   TermId
 	Season TermSeason
 	Year   TermYear
 }
@@ -19,5 +21,6 @@ type Term struct {
 func NewTerm(name TermName, uwTermId int) Term {
 	year := TermYear(uwTermId/10 + 1900)
 	season := TermSeason(uwTermId % 10)
-	return Term{Name: name, Season: season, Year: year}
+	id := TermId(uwTermId)
+	return Term{Name: name, Id: id, Season: season, Year: year}
 }

--- a/internal/app/components/terms/terms_test.go
+++ b/internal/app/components/terms/terms_test.go
@@ -11,13 +11,13 @@ func TestNewTerm(t *testing.T) {
 
 	termName = TermName("1A")
 	term = NewTerm(termName, 1179)
-	assert.Equal(t, Term{Name: termName, Season: FALL, Year: TermYear(2017)}, term)
+	assert.Equal(t, Term{Name: termName, Id: TermId(1179), Season: FALL, Year: TermYear(2017)}, term)
 
 	termName = TermName("1B")
 	term = NewTerm(termName, 1181)
-	assert.Equal(t, Term{Name: termName, Season: WINTER, Year: TermYear(2018)}, term)
+	assert.Equal(t, Term{Name: termName, Id: TermId(1181), Season: WINTER, Year: TermYear(2018)}, term)
 
 	termName = TermName("a long time ago")
 	term = NewTerm(termName, 105)
-	assert.Equal(t, Term{Name: termName, Season: SPRING, Year: TermYear(1910)}, term)
+	assert.Equal(t, Term{Name: termName, Id: TermId(105), Season: SPRING, Year: TermYear(1910)}, term)
 }

--- a/internal/app/components/timelines/timelines.go
+++ b/internal/app/components/timelines/timelines.go
@@ -22,12 +22,11 @@ func newTimelineId() TimelineId {
 	return TimelineId(xid.New().String())
 }
 
-// TODO: use cr parameter when creating Timeline
-func NewTimeline(name TimelineName, cr *courses.CourseRecords) *Timeline {
+func NewTimeline(name TimelineName, tr []*terms.TermRecord) *Timeline {
 	return &Timeline{
 		Id:          newTimelineId(),
 		Name:        name,
-		TermRecords: []*terms.TermRecord{},
+		TermRecords: tr,
 		Plans:       plans.Plans{},
 	}
 }

--- a/internal/app/components/timelines/timelines.go
+++ b/internal/app/components/timelines/timelines.go
@@ -22,11 +22,18 @@ func newTimelineId() TimelineId {
 	return TimelineId(xid.New().String())
 }
 
-func NewTimeline(name TimelineName, tr []*terms.TermRecord) *Timeline {
+func NewTimeline(name TimelineName, courseHistory []*terms.TermRecord) *Timeline {
+	historyCopy := make()[]*terms.TermRecord{}, len(courseHistory))
+	for _, tr := range courseHistory {
+		uwTermId := int(tr.Term.Season) + (int(tr.Term.Year)-1900)*10
+		newRecord := terms.NewTermRecord(tr.Term.Name, uwTermId)
+		copy(newRecord.CourseRecords, tr.CourseRecords)
+		historyCopy = append(historyCopy, newRecord)
+	}
 	return &Timeline{
 		Id:          newTimelineId(),
 		Name:        name,
-		TermRecords: tr,
+		TermRecords: historyCopy,
 		Plans:       plans.Plans{},
 	}
 }

--- a/internal/app/components/timelines/timelines.go
+++ b/internal/app/components/timelines/timelines.go
@@ -23,18 +23,7 @@ func newTimelineId() TimelineId {
 }
 
 func NewTimeline(name TimelineName, courseHistory []*terms.TermRecord) *Timeline {
-	var historyCopy []*terms.TermRecord
-	for _, tr := range courseHistory {
-		uwTermId := int(tr.Term.Season) + (int(tr.Term.Year)-1900)*10
-		newRecord := terms.NewTermRecord(tr.Term.Name, uwTermId)
-		for _, cr := range tr.CourseRecords {
-			copyTime := *cr.CompletionDate
-			tempCourseRecord := cr
-			tempCourseRecord.CompletionDate = &copyTime
-			newRecord.CourseRecords = append(newRecord.CourseRecords, tempCourseRecord)
-		}
-		historyCopy = append(historyCopy, newRecord)
-	}
+	historyCopy := terms.CopyRecords(courseHistory)
 	return &Timeline{
 		Id:          newTimelineId(),
 		Name:        name,

--- a/internal/app/components/timelines/timelines.go
+++ b/internal/app/components/timelines/timelines.go
@@ -23,11 +23,16 @@ func newTimelineId() TimelineId {
 }
 
 func NewTimeline(name TimelineName, courseHistory []*terms.TermRecord) *Timeline {
-	historyCopy := make()[]*terms.TermRecord{}, len(courseHistory))
+	var historyCopy []*terms.TermRecord
 	for _, tr := range courseHistory {
 		uwTermId := int(tr.Term.Season) + (int(tr.Term.Year)-1900)*10
 		newRecord := terms.NewTermRecord(tr.Term.Name, uwTermId)
-		copy(newRecord.CourseRecords, tr.CourseRecords)
+		for _, cr := range tr.CourseRecords {
+			copyTime := *cr.CompletionDate
+			tempCourseRecord := cr
+			tempCourseRecord.CompletionDate = &copyTime
+			newRecord.CourseRecords = append(newRecord.CourseRecords, tempCourseRecord)
+		}
 		historyCopy = append(historyCopy, newRecord)
 	}
 	return &Timeline{

--- a/internal/app/components/timelines/timelines_test.go
+++ b/internal/app/components/timelines/timelines_test.go
@@ -457,7 +457,7 @@ func TestTimeline_InvalidCourses(t *testing.T) {
 	}
 }
 
-func TestTimeline_NewTimeline(t *testing.T) {
+func TestNewTimeline(t *testing.T) {
 	currTime := time.Now()
 	timelineName := TimelineName("timelineName")
 	courseHistory := []*terms.TermRecord{

--- a/internal/app/components/timelines/timelines_test.go
+++ b/internal/app/components/timelines/timelines_test.go
@@ -445,3 +445,76 @@ func TestTimeline_InvalidCourses(t *testing.T) {
 		})
 	}
 }
+
+func TestTimeline_NewTimeline(t *testing.T) {
+	currTime := time.Now()
+	timelineName := TimelineName("timelineName")
+	courseHistory := []*terms.TermRecord{
+		{
+			Term: terms.Term{
+				Name:   "1A",
+				Season: 9,
+				Year:   2018,
+			},
+			CourseRecords: courses.CourseRecords{
+				&courses.CourseRecord{
+					Course: courses.Course{
+						Id: 0,
+					},
+					Grade:          85,
+					CompletionDate: &currTime,
+				},
+			},
+		},
+		{
+			Term: terms.Term{
+				Name:   "1B",
+				Season: 1,
+				Year:   2019,
+			},
+			CourseRecords: courses.CourseRecords{
+				&courses.CourseRecord{
+					Course: courses.Course{
+						Id: 1,
+					},
+					Grade:          70,
+					CompletionDate: &currTime,
+				},
+				&courses.CourseRecord{
+					Course: courses.Course{
+						Id: 2,
+					},
+					Grade:          50,
+					CompletionDate: &currTime,
+				},
+			},
+		},
+		{
+			Term: terms.Term{
+				Name:   "2A",
+				Season: 5,
+				Year:   2019,
+			},
+			CourseRecords: courses.CourseRecords{
+				&courses.CourseRecord{
+					Course: courses.Course{
+						Id: 3,
+					},
+				},
+			},
+		},
+	}
+	newTimeline := NewTimeline(timelineName, courseHistory)
+	courseHistory[1].Term.Season = 5
+	courseHistory[1].CourseRecords[1].Course.Id = 10
+	courseHistory[1].CourseRecords[1].Grade = 100
+	courseHistory[1].Term.Name = "3A"
+	courseHistory[1].Term.Year = 3019
+
+	assert.Equal(t, courseHistory[0].Term, newTimeline.TermRecords[0].Term)
+	assert.Equal(t, courseHistory[0].CourseRecords, newTimeline.TermRecords[0].CourseRecords)
+	assert.NotEqual(t, courseHistory[1].Term, newTimeline.TermRecords[1].Term)
+	assert.NotEqual(t, courseHistory[1].CourseRecords, newTimeline.TermRecords[1].CourseRecords)
+	assert.Equal(t, courseHistory[2].Term, newTimeline.TermRecords[2].Term)
+	assert.Equal(t, courseHistory[2].CourseRecords, newTimeline.TermRecords[2].CourseRecords)
+}

--- a/internal/app/components/timelines/timelines_test.go
+++ b/internal/app/components/timelines/timelines_test.go
@@ -453,9 +453,10 @@ func TestTimeline_NewTimeline(t *testing.T) {
 		{
 			Term: terms.Term{
 				Name:   "1A",
-				Season: 9,
+				Season: terms.TermSeason(9),
 				Year:   2018,
 			},
+			Id: "#131ijj2",
 			CourseRecords: courses.CourseRecords{
 				&courses.CourseRecord{
 					Course: courses.Course{
@@ -469,7 +470,7 @@ func TestTimeline_NewTimeline(t *testing.T) {
 		{
 			Term: terms.Term{
 				Name:   "1B",
-				Season: 1,
+				Season: terms.TermSeason(1),
 				Year:   2019,
 			},
 			CourseRecords: courses.CourseRecords{
@@ -492,7 +493,7 @@ func TestTimeline_NewTimeline(t *testing.T) {
 		{
 			Term: terms.Term{
 				Name:   "2A",
-				Season: 5,
+				Season: terms.TermSeason(5),
 				Year:   2019,
 			},
 			CourseRecords: courses.CourseRecords{
@@ -505,16 +506,18 @@ func TestTimeline_NewTimeline(t *testing.T) {
 		},
 	}
 	newTimeline := NewTimeline(timelineName, courseHistory)
-	courseHistory[1].Term.Season = 5
+	courseHistory[1].Term.Season = terms.TermSeason(5)
 	courseHistory[1].CourseRecords[1].Course.Id = 10
 	courseHistory[1].CourseRecords[1].Grade = 100
 	courseHistory[1].Term.Name = "3A"
 	courseHistory[1].Term.Year = 3019
 
-	assert.Equal(t, courseHistory[0].Term, newTimeline.TermRecords[0].Term)
-	assert.Equal(t, courseHistory[0].CourseRecords, newTimeline.TermRecords[0].CourseRecords)
-	assert.NotEqual(t, courseHistory[1].Term, newTimeline.TermRecords[1].Term)
-	assert.NotEqual(t, courseHistory[1].CourseRecords, newTimeline.TermRecords[1].CourseRecords)
-	assert.Equal(t, courseHistory[2].Term, newTimeline.TermRecords[2].Term)
-	assert.Equal(t, courseHistory[2].CourseRecords, newTimeline.TermRecords[2].CourseRecords)
+	// have to check that each individual one is not equals
+	assert.Equal(t, courseHistory[0].Term, newTimeline)
+	//assert.NotEqual(t, courseHistory[0].Id, newTimeline.TermRecords[0].Id)
+	//assert.Equal(t, courseHistory[0].CourseRecords, newTimeline.TermRecords[0].CourseRecords)
+	//assert.NotEqual(t, courseHistory[1].Term, newTimeline.TermRecords[1].Term)
+	//assert.NotEqual(t, courseHistory[1].CourseRecords, newTimeline.TermRecords[1].CourseRecords)
+	//assert.Equal(t, courseHistory[2].Term, newTimeline.TermRecords[2].Term)
+	//assert.Equal(t, courseHistory[2].CourseRecords, newTimeline.TermRecords[2].CourseRecords)
 }

--- a/internal/app/components/timelines/timelines_test.go
+++ b/internal/app/components/timelines/timelines_test.go
@@ -453,6 +453,7 @@ func TestTimeline_NewTimeline(t *testing.T) {
 		{
 			Term: terms.Term{
 				Name:   "1A",
+				Id: 	1189,
 				Season: terms.TermSeason(9),
 				Year:   2018,
 			},
@@ -470,6 +471,7 @@ func TestTimeline_NewTimeline(t *testing.T) {
 		{
 			Term: terms.Term{
 				Name:   "1B",
+				Id:		1191,
 				Season: terms.TermSeason(1),
 				Year:   2019,
 			},
@@ -493,6 +495,7 @@ func TestTimeline_NewTimeline(t *testing.T) {
 		{
 			Term: terms.Term{
 				Name:   "2A",
+				Id:		1195,
 				Season: terms.TermSeason(5),
 				Year:   2019,
 			},
@@ -501,23 +504,39 @@ func TestTimeline_NewTimeline(t *testing.T) {
 					Course: courses.Course{
 						Id: 3,
 					},
+					Grade:          50,
+					CompletionDate: &currTime,
 				},
 			},
 		},
 	}
+	id := newTimelineId()
+	originTimeline := Timeline{id, timelineName, courseHistory, plans.Plans{}}
 	newTimeline := NewTimeline(timelineName, courseHistory)
-	courseHistory[1].Term.Season = terms.TermSeason(5)
-	courseHistory[1].CourseRecords[1].Course.Id = 10
-	courseHistory[1].CourseRecords[1].Grade = 100
-	courseHistory[1].Term.Name = "3A"
-	courseHistory[1].Term.Year = 3019
 
-	// have to check that each individual one is not equals
-	assert.Equal(t, courseHistory[0].Term, newTimeline)
-	//assert.NotEqual(t, courseHistory[0].Id, newTimeline.TermRecords[0].Id)
-	//assert.Equal(t, courseHistory[0].CourseRecords, newTimeline.TermRecords[0].CourseRecords)
-	//assert.NotEqual(t, courseHistory[1].Term, newTimeline.TermRecords[1].Term)
-	//assert.NotEqual(t, courseHistory[1].CourseRecords, newTimeline.TermRecords[1].CourseRecords)
-	//assert.Equal(t, courseHistory[2].Term, newTimeline.TermRecords[2].Term)
-	//assert.Equal(t, courseHistory[2].CourseRecords, newTimeline.TermRecords[2].CourseRecords)
+	// checks if the second term record is the same
+	assert.Equal(t, originTimeline.TermRecords[1].Term, newTimeline.TermRecords[1].Term)
+	assert.Equal(t, originTimeline.TermRecords[1].CourseRecords, newTimeline.TermRecords[1].CourseRecords)
+
+	originTimeline.TermRecords[1].Term.Season = terms.TermSeason(5)
+	originTimeline.TermRecords[1].CourseRecords[1].Course.Id = 10
+	originTimeline.TermRecords[1].CourseRecords[1].Grade = 100
+	originTimeline.TermRecords[1].Term.Name = "3A"
+	originTimeline.TermRecords[1].Term.Year = 3019
+
+	// check if the other fields are the same
+	assert.Equal(t, originTimeline.Name, newTimeline.Name)
+	assert.NotEqual(t, originTimeline.Id, newTimeline.Id)
+	// check if the first term is the same
+	assert.Equal(t, originTimeline.TermRecords[0].Term, newTimeline.TermRecords[0].Term)
+	assert.NotEqual(t, originTimeline.TermRecords[0].Id, newTimeline.TermRecords[0].Id)
+	assert.Equal(t, originTimeline.TermRecords[0].CourseRecords, newTimeline.TermRecords[0].CourseRecords)
+	// check if second term record changed
+	assert.NotEqual(t, originTimeline.TermRecords[1].Term, newTimeline.TermRecords[1].Term)
+	assert.NotEqual(t, originTimeline.TermRecords[1].CourseRecords, newTimeline.TermRecords[1].CourseRecords)
+	assert.NotEqual(t, originTimeline.TermRecords[1].Id, newTimeline.TermRecords[1].Id)
+	// check if the third term record is the same
+	assert.NotEqual(t, originTimeline.TermRecords[2].Id, newTimeline.TermRecords[2].Id)
+	assert.Equal(t, originTimeline.TermRecords[2].Term, newTimeline.TermRecords[2].Term)
+	assert.Equal(t, originTimeline.TermRecords[2].CourseRecords, newTimeline.TermRecords[2].CourseRecords)
 }

--- a/internal/app/components/users/users.go
+++ b/internal/app/components/users/users.go
@@ -2,9 +2,8 @@ package users
 
 import (
 	"context"
-	"github.com/gzcharleszhang/course-planner/internal/app/components/courses"
-	"github.com/gzcharleszhang/course-planner/internal/app/components/timelines"
 	"github.com/gzcharleszhang/course-planner/internal/app/components/terms"
+	"github.com/gzcharleszhang/course-planner/internal/app/components/timelines"
 	"github.com/gzcharleszhang/course-planner/internal/app/db"
 	"github.com/rs/xid"
 	"go.mongodb.org/mongo-driver/bson"
@@ -17,12 +16,12 @@ type UserId string
 type PasswordHash string
 
 type UserData struct {
-	Id            UserId                   `bson:"_id"`
-	FirstName     FirstName                `bson:"first_name"`
-	LastName      LastName                 `bson:"last_name"`
-	Password      PasswordHash             `bson:"password"`
-	CourseHistory []terms.TermRecordId     `bson:"course_history"`
-	Timelines     []timelines.TimelineId   `bson:"timelines"`
+	Id            UserId                 `bson:"_id"`
+	FirstName     FirstName              `bson:"first_name"`
+	LastName      LastName               `bson:"last_name"`
+	Password      PasswordHash           `bson:"password"`
+	CourseHistory []terms.TermRecordId   `bson:"course_history"`
+	Timelines     []timelines.TimelineId `bson:"timelines"`
 }
 
 type User struct {
@@ -67,7 +66,7 @@ func GetUserById(ctx context.Context, userId UserId) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	history, err := courses.GetCourseRecordsByIds(ctx, result.CourseHistory)
+	history, err := terms.GetTermRecordsByIds(ctx, result.CourseHistory)
 	if err != nil {
 		return nil, err
 	}
@@ -92,6 +91,6 @@ func HashPassword(password string) (PasswordHash, error) {
 }
 
 // Creates a new timemline with the courses added to the course CourseHistory
-func (usr User) UpdateTimeline(name TimelineName) {
-	usr.Timelines = append(usr.Timelines, NewTimeline(name, usr.CourseHistory));
+func (usr User) NewTimeline(name timelines.TimelineName) {
+	usr.Timelines = append(usr.Timelines, timelines.NewTimeline(name, usr.CourseHistory))
 }

--- a/internal/app/components/users/users.go
+++ b/internal/app/components/users/users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/gzcharleszhang/course-planner/internal/app/components/courses"
 	"github.com/gzcharleszhang/course-planner/internal/app/components/timelines"
+	"github.com/gzcharleszhang/course-planner/internal/app/components/terms"
 	"github.com/gzcharleszhang/course-planner/internal/app/db"
 	"github.com/rs/xid"
 	"go.mongodb.org/mongo-driver/bson"
@@ -20,7 +21,7 @@ type UserData struct {
 	FirstName     FirstName                `bson:"first_name"`
 	LastName      LastName                 `bson:"last_name"`
 	Password      PasswordHash             `bson:"password"`
-	CourseHistory []courses.CourseRecordId `bson:"course_history"`
+	CourseHistory []terms.TermRecordId     `bson:"course_history"`
 	Timelines     []timelines.TimelineId   `bson:"timelines"`
 }
 
@@ -29,7 +30,7 @@ type User struct {
 	FirstName     FirstName             `bson:"first_name"`
 	LastName      LastName              `bson:"last_name"`
 	Password      PasswordHash          `bson:"password"`
-	CourseHistory courses.CourseRecords `bson:"course_history"`
+	CourseHistory []*terms.TermRecord   `bson:"course_history"`
 	Timelines     []*timelines.Timeline `bson:"timelines"`
 }
 
@@ -88,4 +89,9 @@ func GetUserById(ctx context.Context, userId UserId) (*User, error) {
 func HashPassword(password string) (PasswordHash, error) {
 	bytes, err := bcrypt.GenerateFromPassword([]byte(password), 14)
 	return PasswordHash(bytes), err
+}
+
+// Creates a new timemline with the courses added to the course CourseHistory
+func (usr User) UpdateTimeline(name TimelineName) {
+	usr.Timelines = append(usr.Timelines, NewTimeline(name, usr.CourseHistory));
 }


### PR DESCRIPTION
Closes #28. Modified course history to be array of term records pointers and functions to use course history to build timelines.